### PR TITLE
로그인 유지되도록 context 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@
 # 3. 값 부분에 민감한 정보들을 넣는다
 # ex) base_url -> 팀 노션 해당 프로젝트 커뮤니티 센터 - 목업 API 부분 참고
 
-API_BASE_URL=base_url
+NEXT_REPUBLIC_API_BASE_URL=base_url

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,8 +1,10 @@
-import { AuthCredentials } from "@/types/auth";
+import { AuthCredentials, AuthResponse } from "@/types/auth";
 import { client } from "../../client";
 
-export const login = async (credentials: AuthCredentials): Promise<string> => {
-	const response = await client<string>("auth/login", {
+export const userLogin = async (
+	credentials: AuthCredentials
+): Promise<AuthResponse> => {
+	const response = await client<AuthResponse>("auth/login", {
 		method: "POST",
 		body: JSON.stringify(credentials),
 	});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ import { client } from "../../client";
 export const userLogin = async (
 	credentials: AuthCredentials
 ): Promise<AuthResponse> => {
-	const response = await client<AuthResponse>("auth/login", {
+	const response = await client<AuthResponse>("/auth/login", {
 		method: "POST",
 		body: JSON.stringify(credentials),
 	});

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -7,6 +7,7 @@ interface ApiError extends Error {
 
 interface RequestConfig extends RequestInit {
 	params?: Record<string, string>;
+	requireAuth?: boolean; // 인증이 필요한 요청인지 여부
 }
 
 /**
@@ -16,10 +17,16 @@ interface RequestConfig extends RequestInit {
  */
 async function client<T>(
 	endpoint: string,
-	{ params, ...customConfig }: RequestConfig = {}
+	{ params, requireAuth = true, ...customConfig }: RequestConfig = {}
 ): Promise<T> {
+	// TODO: 로컬스토리지 -> 쿠키로 변경하기?
+	const accessToken = localStorage.getItem("aeecssToken");
+
 	const headers = {
 		"Content-Type": "application/json",
+		...(requireAuth && accessToken
+			? { Authorization: `Bearer ${accessToken}` }
+			: {}),
 		...customConfig.headers,
 	};
 

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = "https://localhost:8000"; // 임시
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 interface ApiError extends Error {
 	statusCode: number;

--- a/src/app/api/product/route.ts
+++ b/src/app/api/product/route.ts
@@ -1,4 +1,4 @@
-import { Product, ProductResponse } from "@/types/product";
+import { ProductResponse } from "@/types/product";
 import { client } from "../client";
 
 // const ITEM_COUNT = 12;
@@ -9,7 +9,7 @@ export const getProducts = async (): // page: number = 1,
 // itemCount: number = ITEM_COUNT,
 // category: string = "all"
 Promise<ProductResponse> => {
-	return client<ProductResponse>("products", {
+	return client<ProductResponse>("/products", {
 		params: {},
 	});
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Layout from "@/components/layout/Layout";
+import Providers from "@/providers";
 import "@/styles/global.css";
 
 export default function RootLayout({
@@ -9,7 +10,9 @@ export default function RootLayout({
 	return (
 		<html>
 			<body suppressHydrationWarning>
-				<Layout>{children}</Layout>
+				<Providers>
+					<Layout>{children}</Layout>
+				</Providers>
 			</body>
 		</html>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ProductList from "@/components/product/ProductList";
+import ProductList from "@/components/product/ProductList/ProductList";
 
 export default function HomePage() {
 	return <ProductList />;

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -1,4 +1,3 @@
-import { login, userLogin } from "@/app/api/auth/login/route";
 import useAuth from "@/hooks/useAuth";
 import { validateId, validatePassword } from "@/utils/validate";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
@@ -56,7 +55,7 @@ const useLoginForm = ({ onSuccess, onError }: UseLoginFormProps) => {
 		if (!validateForm()) return;
 
 		try {
-			// await login({ userId: formState.id, password: formState.password });
+			await login({ userId: formState.id, password: formState.password });
 			onSuccess?.();
 		} catch (error) {
 			const errorMessage =

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -1,4 +1,5 @@
-import { login } from "@/app/api/auth/login/route";
+import { login, userLogin } from "@/app/api/auth/login/route";
+import useAuth from "@/hooks/useAuth";
 import { validateId, validatePassword } from "@/utils/validate";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
 
@@ -25,6 +26,7 @@ const useLoginForm = ({ onSuccess, onError }: UseLoginFormProps) => {
 		password: "",
 	});
 	const [errors, setErrors] = useState<FormErrors>({});
+	const { login } = useAuth();
 
 	const validateForm = useCallback(() => {
 		const newErrors: FormErrors = {};
@@ -54,8 +56,7 @@ const useLoginForm = ({ onSuccess, onError }: UseLoginFormProps) => {
 		if (!validateForm()) return;
 
 		try {
-			await login({ userId: formState.id, password: formState.password });
-
+			// await login({ userId: formState.id, password: formState.password });
 			onSuccess?.();
 		} catch (error) {
 			const errorMessage =

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -54,7 +54,7 @@ const useLoginForm = ({ onSuccess, onError }: UseLoginFormProps) => {
 		if (!validateForm()) return;
 
 		try {
-			await login({ id: formState.id, password: formState.password });
+			await login({ userId: formState.id, password: formState.password });
 
 			onSuccess?.();
 		} catch (error) {

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,7 +1,10 @@
+import useAuth from "@/hooks/useAuth";
 import Link from "next/link";
 import React from "react";
 
 const Header = () => {
+	const { isLoggedIn, logout } = useAuth();
+
 	return (
 		<header className="w-full mx-auto h-[4rem] flex justify-between items-center p-4">
 			<div>
@@ -16,9 +19,17 @@ const Header = () => {
 				<Link href="/mypage" className="flex gap-2 px-4  cursor-pointer">
 					<span className="text-link">My Page</span>
 				</Link>
-				<Link href="/login" className="flex gap-2 px-4  cursor-pointer">
-					<span className="text-link">로그인</span>
-				</Link>
+				{isLoggedIn ? (
+					<div className="flex gap-2 px-4  cursor-pointer">
+						<span className="text-link" onClick={logout}>
+							로그아웃
+						</span>
+					</div>
+				) : (
+					<Link href="/login" className="flex gap-2 px-4  cursor-pointer">
+						<span className="text-link">로그인</span>
+					</Link>
+				)}
 			</div>
 		</header>
 	);

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { AuthContext } from "@/providers/AuthProvider";
+import React, { useContext } from "react";
+
+const useAuth = () => {
+	const context = useContext(AuthContext);
+	if (!context) {
+		throw new Error("useAuth는 AuthProvider의 안에서만 사용해야 합니다.");
+	}
+	return context;
+};
+
+export default useAuth;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { userLogin } from "@/app/api/auth/login/route";
+import { AuthCredentials, AuthResponse, DecodedToken } from "@/types/auth";
+import { decodeJwt } from "@/utils/decodeJwt";
+import { createContext, useEffect, useState } from "react";
+
+interface AuthContextType {
+	user: DecodedToken | null;
+	isLoggedIn: boolean;
+	login: (credentials: AuthCredentials) => Promise<AuthResponse>;
+	logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(
+	undefined
+);
+
+const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+	const [user, setUser] = useState<DecodedToken | null>(null);
+
+	// 초기 로딩 시 토큰이 localStorage에 있으면 복원
+	useEffect(() => {
+		const token = localStorage.getItem("access_token");
+		if (token) {
+			const decoded = decodeJwt<DecodedToken>(token);
+			if (decoded) {
+				setUser(decoded);
+			} else {
+				localStorage.removeItem("access_token");
+			}
+		}
+	}, []);
+
+	const login = async (credentials: AuthCredentials) => {
+		const response = await userLogin(credentials);
+		const decoded = decodeJwt<DecodedToken>(response.accessToken);
+		if (decoded) setUser(decoded);
+		localStorage.setItem("access_token", response.accessToken);
+		return response;
+	};
+
+	const logout = () => {
+		localStorage.removeItem("access_token");
+		setUser(null);
+	};
+
+	const isLoggedIn = !!user?.sub;
+
+	return (
+		<AuthContext.Provider value={{ user, isLoggedIn, login, logout }}>
+			{children}
+		</AuthContext.Provider>
+	);
+};
+
+export default AuthProvider;

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import AuthProvider from "./AuthProvider";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+	return <AuthProvider>{children}</AuthProvider>;
+}

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,5 +1,5 @@
 export interface AuthCredentials {
-	id: string;
+	userId: string;
 	password: string;
 }
 

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -12,3 +12,10 @@ export interface AuthError extends Error {
 	statusCode?: number;
 	code?: string;
 }
+
+export interface DecodedToken {
+	sub: string; // 유저 ID
+	role: string;
+	iat: number; // 생성 시간
+	exp: number; // 만료 시간
+}

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -4,8 +4,8 @@ export interface AuthCredentials {
 }
 
 export interface AuthResponse {
-	access_token: string;
-	refresh_token: string;
+	accessToken: string;
+	refreshToken: string;
 }
 
 export interface AuthError extends Error {

--- a/src/utils/decodeJwt.ts
+++ b/src/utils/decodeJwt.ts
@@ -1,0 +1,21 @@
+/**
+ * JWT 토큰 디코딩
+ * Base64 디코딩만 수행하므로 서명 검증은 하지 않습니다.
+ */
+export const decodeJwt = <T>(token: string): T | null => {
+	try {
+		const base64Url = token.split(".")[1];
+		const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+		const jsonPayload = decodeURIComponent(
+			atob(base64)
+				.split("")
+				.map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+				.join("")
+		);
+
+		return JSON.parse(jsonPayload);
+	} catch (error) {
+		console.error("JWT 디코딩 실패:", error);
+		return null;
+	}
+};


### PR DESCRIPTION
## 작업내역
- 사용자가 로그인 했을 때 accessToken을 로컬스토리지에 저장하고 로그인 유지되도록 적용
  - 나중에 쿠키로 변경 필요(보안때문에..)
- 로그인/로그아웃 유무에 따라 헤더 버튼 변경되도록 수정
- env파일에 BASE_URL 이름 변경 -> NEXT_PUBLIC_BASE_URL
  - 클라이언트에서 사용하려면 접두어 붙여야한대요..


## 스크린샷
<img width="906" alt="스크린샷 2025-03-26 오후 1 03 33" src="https://github.com/user-attachments/assets/695980c9-f4f2-4953-a7da-a1da5c8f163a" />
