### PR TITLE
아이템 상세화면 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "evenly",
 			"version": "0.1.0",
 			"dependencies": {
+				"lucide-react": "^0.484.0",
 				"next": "15.2.2",
 				"postcss": "^8.5.3",
 				"react": "^19.0.0",
@@ -1150,9 +1151,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.0.11",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.11.tgz",
-			"integrity": "sha512-vrdxRZfo9ALXth6yPfV16PYTLZwsUWhVjjC+DkfE5t1suNSbBrWC9YqSuuxJZ8Ps6z1o2ycRpIqzZJIgklq4Tw==",
+			"version": "19.0.12",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
+			"integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1170,17 +1171,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.1.tgz",
-			"integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.27.0.tgz",
+			"integrity": "sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.26.1",
-				"@typescript-eslint/type-utils": "8.26.1",
-				"@typescript-eslint/utils": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1",
+				"@typescript-eslint/scope-manager": "8.27.0",
+				"@typescript-eslint/type-utils": "8.27.0",
+				"@typescript-eslint/utils": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1200,16 +1201,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.1.tgz",
-			"integrity": "sha512-w6HZUV4NWxqd8BdeFf81t07d7/YV9s7TCWrQQbG5uhuvGUAW+fq1usZ1Hmz9UPNLniFnD8GLSsDpjP0hm1S4lQ==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.27.0.tgz",
+			"integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.26.1",
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/typescript-estree": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1",
+				"@typescript-eslint/scope-manager": "8.27.0",
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/typescript-estree": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1225,14 +1226,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
-			"integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
+			"integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1"
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1243,14 +1244,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.1.tgz",
-			"integrity": "sha512-Kcj/TagJLwoY/5w9JGEFV0dclQdyqw9+VMndxOJKtoFSjfZhLXhYjzsQEeyza03rwHx2vFEGvrJWJBXKleRvZg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.27.0.tgz",
+			"integrity": "sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.26.1",
-				"@typescript-eslint/utils": "8.26.1",
+				"@typescript-eslint/typescript-estree": "8.27.0",
+				"@typescript-eslint/utils": "8.27.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.0.1"
 			},
@@ -1267,9 +1268,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
-			"integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
+			"integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1281,14 +1282,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
-			"integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
+			"integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1",
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1364,16 +1365,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
-			"integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
+			"integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.26.1",
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/typescript-estree": "8.26.1"
+				"@typescript-eslint/scope-manager": "8.27.0",
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/typescript-estree": "8.27.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1388,13 +1389,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
-			"integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
+			"integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
+				"@typescript-eslint/types": "8.27.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -1406,9 +1407,9 @@
 			}
 		},
 		"node_modules/@unrs/rspack-resolver-binding-darwin-arm64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.1.2.tgz",
-			"integrity": "sha512-bQx2L40UF5XxsXwkD26PzuspqUbUswWVbmclmUC+c83Cv/EFrFJ1JaZj5Q5jyYglKGOtyIWY/hXTCdWRN9vT0Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-arm64/-/rspack-resolver-binding-darwin-arm64-1.2.2.tgz",
+			"integrity": "sha512-i7z0B+C0P8Q63O/5PXJAzeFtA1ttY3OR2VSJgGv18S+PFNwD98xHgAgPOT1H5HIV6jlQP8Avzbp09qxJUdpPNw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1420,9 +1421,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-darwin-x64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.1.2.tgz",
-			"integrity": "sha512-dMi9a7//BsuPTnhWEDxmdKZ6wxQlPnAob8VSjefGbKX/a+pHfTaX1pm/jv2VPdarP96IIjCKPatJS/TtLQeGQA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-darwin-x64/-/rspack-resolver-binding-darwin-x64-1.2.2.tgz",
+			"integrity": "sha512-YEdFzPjIbDUCfmehC6eS+AdJYtFWY35YYgWUnqqTM2oe/N58GhNy5yRllxYhxwJ9GcfHoNc6Ubze1yjkNv+9Qg==",
 			"cpu": [
 				"x64"
 			],
@@ -1434,9 +1435,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-freebsd-x64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.1.2.tgz",
-			"integrity": "sha512-RiBZQ+LSORQObfhV1yH7jGz+4sN3SDYtV53jgc8tUVvqdqVDaUm1KA3zHLffmoiYNGrYkE3sSreGC+FVpsB4Vg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-freebsd-x64/-/rspack-resolver-binding-freebsd-x64-1.2.2.tgz",
+			"integrity": "sha512-TU4ntNXDgPN2giQyyzSnGWf/dVCem5lvwxg0XYvsvz35h5H19WrhTmHgbrULMuypCB3aHe1enYUC9rPLDw45mA==",
 			"cpu": [
 				"x64"
 			],
@@ -1448,9 +1449,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.1.2.tgz",
-			"integrity": "sha512-IyKIFBtOvuPCJt1WPx9e9ovTGhZzrIbW11vWzw4aPmx3VShE+YcMpAldqQubdCep0UVKZyFt+2hQDQZwFiJ4jg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm-gnueabihf/-/rspack-resolver-binding-linux-arm-gnueabihf-1.2.2.tgz",
+			"integrity": "sha512-ik3w4/rU6RujBvNWiDnKdXi1smBhqxEDhccNi/j2rHaMjm0Fk49KkJ6XKsoUnD2kZ5xaMJf9JjailW/okfUPIw==",
 			"cpu": [
 				"arm"
 			],
@@ -1462,9 +1463,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-linux-arm64-gnu": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.1.2.tgz",
-			"integrity": "sha512-RfYtlCtJrv5i6TO4dSlpbyOJX9Zbhmkqrr9hjDfr6YyE5KD0ywLRzw8UjXsohxG1XWgRpb2tvPuRYtURJwbqWg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-gnu/-/rspack-resolver-binding-linux-arm64-gnu-1.2.2.tgz",
+			"integrity": "sha512-fp4Azi8kHz6TX8SFmKfyScZrMLfp++uRm2srpqRjsRZIIBzH74NtSkdEUHImR4G7f7XJ+sVZjCc6KDDK04YEpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1476,9 +1477,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-linux-arm64-musl": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.1.2.tgz",
-			"integrity": "sha512-MaITzkoqsn1Rm3+YnplubgAQEfOt+2jHfFvuFhXseUfcfbxe8Zyc3TM7LKwgv7mRVjIl+/yYN5JqL0cjbnhAnQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-arm64-musl/-/rspack-resolver-binding-linux-arm64-musl-1.2.2.tgz",
+			"integrity": "sha512-gMiG3DCFioJxdGBzhlL86KcFgt9HGz0iDhw0YVYPsShItpN5pqIkNrI+L/Q/0gfDiGrfcE0X3VANSYIPmqEAlQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1490,9 +1491,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-linux-x64-gnu": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.1.2.tgz",
-			"integrity": "sha512-Nu981XmzQqis/uB3j4Gi3p5BYCd/zReU5zbJmjMrEH7IIRH0dxZpdOmS/+KwEk6ao7Xd8P2D2gDHpHD/QTp0aQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-gnu/-/rspack-resolver-binding-linux-x64-gnu-1.2.2.tgz",
+			"integrity": "sha512-n/4n2CxaUF9tcaJxEaZm+lqvaw2gflfWQ1R9I7WQgYkKEKbRKbpG/R3hopYdUmLSRI4xaW1Cy0Bz40eS2Yi4Sw==",
 			"cpu": [
 				"x64"
 			],
@@ -1504,9 +1505,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-linux-x64-musl": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.1.2.tgz",
-			"integrity": "sha512-xJupeDvaRpV0ADMuG1dY9jkOjhUzTqtykvchiU2NldSD+nafSUcMWnoqzNUx7HGiqbTMOw9d9xT8ZiFs+6ZFyQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-linux-x64-musl/-/rspack-resolver-binding-linux-x64-musl-1.2.2.tgz",
+			"integrity": "sha512-cHyhAr6rlYYbon1L2Ag449YCj3p6XMfcYTP0AQX+KkQo025d1y/VFtPWvjMhuEsE2lLvtHm7GdJozj6BOMtzVg==",
 			"cpu": [
 				"x64"
 			],
@@ -1518,9 +1519,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-wasm32-wasi": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.1.2.tgz",
-			"integrity": "sha512-un6X/xInks+KEgGpIHFV8BdoODHRohaDRvOwtjq+FXuoI4Ga0P6sLRvf4rPSZDvoMnqUhZtVNG0jG9oxOnrrLQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-wasm32-wasi/-/rspack-resolver-binding-wasm32-wasi-1.2.2.tgz",
+			"integrity": "sha512-eogDKuICghDLGc32FtP+WniG38IB1RcGOGz0G3z8406dUdjJvxfHGuGs/dSlM9YEp/v0lEqhJ4mBu6X2nL9pog==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1535,9 +1536,9 @@
 			}
 		},
 		"node_modules/@unrs/rspack-resolver-binding-win32-arm64-msvc": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.1.2.tgz",
-			"integrity": "sha512-2lCFkeT1HYUb/OOStBS1m67aZOf9BQxRA+Wf/xs94CGgzmoQt7H4V/BrkB/GSGKsudXjkiwt2oHNkHiowAS90A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-arm64-msvc/-/rspack-resolver-binding-win32-arm64-msvc-1.2.2.tgz",
+			"integrity": "sha512-7sWRJumhpXSi2lccX8aQpfFXHsSVASdWndLv8AmD8nDRA/5PBi8IplQVZNx2mYRx6+Bp91Z00kuVqpXO9NfCTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1549,9 +1550,9 @@
 			]
 		},
 		"node_modules/@unrs/rspack-resolver-binding-win32-x64-msvc": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.1.2.tgz",
-			"integrity": "sha512-EYfya5HCQ/8Yfy7rvAAX2rGytu81+d/CIhNCbZfNKLQ690/qFsdEeTXRsMQW1afHoluMM50PsjPYu8ndy8fSQg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@unrs/rspack-resolver-binding-win32-x64-msvc/-/rspack-resolver-binding-win32-x64-msvc-1.2.2.tgz",
+			"integrity": "sha512-hewo/UMGP1a7O6FG/ThcPzSJdm/WwrYDNkdGgWl6M18H6K6MSitklomWpT9MUtT5KGj++QJb06va/14QBC4pvw==",
 			"cpu": [
 				"x64"
 			],
@@ -4153,6 +4154,15 @@
 				"loose-envify": "cli.js"
 			}
 		},
+		"node_modules/lucide-react": {
+			"version": "0.484.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.484.0.tgz",
+			"integrity": "sha512-oZy8coK9kZzvqhSgfbGkPtTgyjpBvs3ukLgDPv14dSOZtBtboryWF5o8i3qen7QbGg7JhiJBz5mK1p8YoMZTLQ==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4218,9 +4228,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-			"integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"funding": [
 				{
 					"type": "github",
@@ -4790,26 +4800,26 @@
 			}
 		},
 		"node_modules/rspack-resolver": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.1.2.tgz",
-			"integrity": "sha512-eHhz+9JWHFdbl/CVVqEP6kviLFZqw1s0MWxLdsGMtUKUspSO3SERptPohmrUIC9jT1bGV9Bd3+r8AmWbdfNAzQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.2.tgz",
+			"integrity": "sha512-Fwc19jMBA3g+fxDJH2B4WxwZjE0VaaOL7OX/A4Wn5Zv7bOD/vyPZhzXfaO73Xc2GAlfi96g5fGUa378WbIGfFw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/JounQin"
 			},
 			"optionalDependencies": {
-				"@unrs/rspack-resolver-binding-darwin-arm64": "1.1.2",
-				"@unrs/rspack-resolver-binding-darwin-x64": "1.1.2",
-				"@unrs/rspack-resolver-binding-freebsd-x64": "1.1.2",
-				"@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.1.2",
-				"@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.1.2",
-				"@unrs/rspack-resolver-binding-linux-arm64-musl": "1.1.2",
-				"@unrs/rspack-resolver-binding-linux-x64-gnu": "1.1.2",
-				"@unrs/rspack-resolver-binding-linux-x64-musl": "1.1.2",
-				"@unrs/rspack-resolver-binding-wasm32-wasi": "1.1.2",
-				"@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.1.2",
-				"@unrs/rspack-resolver-binding-win32-x64-msvc": "1.1.2"
+				"@unrs/rspack-resolver-binding-darwin-arm64": "1.2.2",
+				"@unrs/rspack-resolver-binding-darwin-x64": "1.2.2",
+				"@unrs/rspack-resolver-binding-freebsd-x64": "1.2.2",
+				"@unrs/rspack-resolver-binding-linux-arm-gnueabihf": "1.2.2",
+				"@unrs/rspack-resolver-binding-linux-arm64-gnu": "1.2.2",
+				"@unrs/rspack-resolver-binding-linux-arm64-musl": "1.2.2",
+				"@unrs/rspack-resolver-binding-linux-x64-gnu": "1.2.2",
+				"@unrs/rspack-resolver-binding-linux-x64-musl": "1.2.2",
+				"@unrs/rspack-resolver-binding-wasm32-wasi": "1.2.2",
+				"@unrs/rspack-resolver-binding-win32-arm64-msvc": "1.2.2",
+				"@unrs/rspack-resolver-binding-win32-x64-msvc": "1.2.2"
 			}
 		},
 		"node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
+		"lucide-react": "^0.484.0",
 		"next": "15.2.2",
 		"postcss": "^8.5.3",
 		"react": "^19.0.0",

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -20,7 +20,7 @@ async function client<T>(
 	{ params, requireAuth = true, ...customConfig }: RequestConfig = {}
 ): Promise<T> {
 	// TODO: 로컬스토리지 -> 쿠키로 변경하기?
-	const accessToken = localStorage.getItem("aeecssToken");
+	const accessToken = localStorage.getItem("access_token");
 
 	const headers = {
 		"Content-Type": "application/json",

--- a/src/app/api/product/route.ts
+++ b/src/app/api/product/route.ts
@@ -1,4 +1,4 @@
-import { Product, ProductResponse } from "@/types/product";
+import { OrderProduct, Product, ProductResponse } from "@/types/product";
 import { client } from "../client";
 
 /**
@@ -25,5 +25,25 @@ export const getProducts = async ({
 export const getProductById = async (id: number): Promise<Product> => {
 	return client<Product>(`/products/${id}`, {
 		params: {},
+	});
+};
+
+/**
+ * 상품을 장바구니에 추가하는 API
+ */
+export const addProductToCart = async (item: OrderProduct): Promise<void> => {
+	return client<void>(`/cart`, {
+		method: "POST",
+		body: JSON.stringify(item),
+	});
+};
+
+/**
+ * 상품을 결제로 이동하는 API
+ */
+export const orderProduct = async (item: OrderProduct): Promise<void> => {
+	return client<void>(`/orders/create`, {
+		method: "POST",
+		body: JSON.stringify(item),
 	});
 };

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { getProductById } from "@/app/api/product/route";
+import ProductDetail from "@/components/product/ProductDetail";
+import { Product } from "@/types/product";
+import { useParams } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+const ProductDetailPage = () => {
+	const { id } = useParams();
+	const [product, setProduct] = useState<Product | null>(null);
+	const [error, setError] = useState(false);
+
+	useEffect(() => {
+		if (!id) return;
+		fetchProduct();
+	}, []);
+
+	const fetchProduct = async () => {
+		const data = await getProductById(Number(id));
+		setProduct(data);
+	};
+
+	if (error) return <div>존재하지 않는 상품</div>;
+	if (!product) return <div>로딩중</div>;
+
+	return (
+		<div>
+			<ProductDetail product={product} />
+		</div>
+	);
+};
+
+export default ProductDetailPage;

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getProductById } from "@/app/api/product/route";
-import ProductDetail from "@/components/product/ProductDetail";
+import ProductDetail from "@/components/product/ProductDetail/ProductDetail";
 import { Product } from "@/types/product";
 import { useParams } from "next/navigation";
 import React, { useEffect, useState } from "react";

--- a/src/components/common/Button/BaseButton.tsx
+++ b/src/components/common/Button/BaseButton.tsx
@@ -15,7 +15,7 @@ const BaseButton = memo(
 				color = "dustyBlue",
 				leftIcon,
 				rightIcon,
-				// disabled,
+				disabled,
 				className,
 				children,
 				...props
@@ -29,7 +29,12 @@ const BaseButton = memo(
 			}, [size, style, color, className]);
 
 			return (
-				<button ref={ref} className={buttonStyles} {...props}>
+				<button
+					ref={ref}
+					className={buttonStyles}
+					disabled={disabled}
+					{...props}
+				>
 					{leftIcon && <span className="inline-flex">{leftIcon}</span>}
 					{children}
 					{rightIcon && <span className="inline-flex">{rightIcon}</span>}

--- a/src/components/common/Button/styles.ts
+++ b/src/components/common/Button/styles.ts
@@ -28,9 +28,11 @@ export const BUTTON_STYLES: Record<ButtonStyle, Record<ButtonColor, string>> = {
 		icon: "",
 		white: "",
 	},
-	text: {
-		dustyBlue: "text-[#AFC8D9] hover:bg-[#AFC8D9]]/10 active:bg-[#AFC8D9]/20",
-		softKhaki: "text-[#C2B59B] hover:bg-[#C2B59B]/10 active:bg-[#C2B59B]/20",
+	border: {
+		dustyBlue:
+			"text-[#AFC8D9] border border-[#AFC8D9] hover:text-[#AFC8D9]/40 active:text-[#AFC8D9]/40",
+		softKhaki:
+			"text-[#C2B59B] border border-#[C2B59B] hover:text-[#C2B59B]/40 active:text-[#C2B59B]/40",
 		icon: "",
 		white: "",
 	},

--- a/src/components/common/Input/BaseInput.tsx
+++ b/src/components/common/Input/BaseInput.tsx
@@ -69,16 +69,20 @@ const BaseInput = memo(
 							{icon}
 						</div>
 					)}
+					<div className="relative">
+						<input
+							ref={ref}
+							disabled={disabled}
+							className={getInputStyles()}
+							{...props}
+						/>
 
-					<input
-						ref={ref}
-						disabled={disabled}
-						className={getInputStyles()}
-						{...props}
-					/>
-
-					{rightElement && <div>{rightElement}</div>}
-
+						{rightElement && (
+							<div className="absolute right-2 top-1/2 -translate-y-1/2">
+								{rightElement}
+							</div>
+						)}
+					</div>
 					{(error || helper) && (
 						<p
 							className={`mt-1 text-sm ${

--- a/src/components/common/Input/NumberInput.tsx
+++ b/src/components/common/Input/NumberInput.tsx
@@ -1,0 +1,77 @@
+import { BaseInputProps } from "@/types/input";
+import React, { forwardRef, useState } from "react";
+import BaseInput from "./BaseInput";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+export type NumberInputProps = Omit<
+	BaseInputProps,
+	"type" | "rightElement" | "error" | "onChange"
+> & {
+	min?: number;
+	max?: number;
+	value: number;
+	onValueChange?: (value: number) => void;
+};
+
+const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+	({ min = 1, max = 100, value, onValueChange, ...props }, ref) => {
+		const [error, setError] = useState<string>("");
+
+		const handleStep = (step: number) => {
+			let next = value + step;
+			setError("");
+
+			if (next < min) next = min;
+			if (next > max) {
+				setError(`최대 ${max}까지 입력할 수 있습니다.`);
+				next = max;
+			}
+			onValueChange?.(next);
+		};
+
+		const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+			const next = Number(e.target.value);
+			if (Number.isNaN(next)) return;
+			onValueChange?.(next);
+		};
+
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+			e.preventDefault();
+		};
+
+		return (
+			<BaseInput
+				type="number"
+				ref={ref}
+				value={value}
+				onChange={(e) => handleChange(e)}
+				error={error}
+				readOnly
+				onKeyDown={handleKeyDown}
+				rightElement={
+					<div className="flex flex-col items-center gap-0.5">
+						<button
+							type="button"
+							onClick={() => handleStep(1)}
+							className="disabled:opacity-50"
+						>
+							<ChevronUpIcon size={16} />
+						</button>
+						<button
+							type="button"
+							onClick={() => handleStep(-1)}
+							className="disabled:opacity-50"
+						>
+							<ChevronDownIcon size={16} />
+						</button>
+					</div>
+				}
+				{...props}
+			/>
+		);
+	}
+);
+
+NumberInput.displayName = "NumberInput";
+
+export default NumberInput;

--- a/src/components/product/ProductDetail.tsx
+++ b/src/components/product/ProductDetail.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import React, { useState } from "react";
 import BaseButton from "../common/Button/BaseButton";
 import NumberInput from "../common/Input/NumberInput";
+import { formatPrice } from "@/utils/format";
 
 interface ProductDetailProps {
 	product: Product;
@@ -12,8 +13,15 @@ const ProductDetail = ({ product }: ProductDetailProps) => {
 	const [quantity, setQuantity] = useState<number>(1);
 	if (!product) return null;
 
+	const isAvailable = product.status === "AVAILABLE";
+
+	const onClick = () => {
+		console.log("click");
+	};
+
 	return (
 		<div className="flex flex-col md:flex-row w-full gap-8">
+			{/* 이미지 영역 */}
 			<div className="relative w-full max-w-xl aspect-[4/5]">
 				<Image
 					src={product.imageUrl}
@@ -24,41 +32,41 @@ const ProductDetail = ({ product }: ProductDetailProps) => {
 					priority
 				/>
 			</div>
-			<div className="flex flex-col gap-4 w-full md:w-100">
-				<span className="text-2xl font-bold">{product.name}</span>
-
-				<div className="flex flex-col pt-20 gap-4">
-					<span className="text-2xl font-bold">
-						KRW {product.price.toLocaleString()}
-					</span>
-					{product.status === "AVAILABLE" ? (
+			{/* 텍스트 및 조작 영역 */}
+			<div className="flex flex-col pt-2 gap-4 w-full md:max-w-lg">
+				<h1 className="text-2xl font-bold">{product.name}</h1>
+				<div className="flex flex-col pt-24 gap-4">
+					<h2 className="text-2xl font-bold">{formatPrice(product.price)}</h2>
+					{isAvailable ? (
 						<NumberInput
 							value={quantity}
 							onValueChange={setQuantity}
 							max={product.stock}
 						/>
 					) : (
-						<span>Sold Out</span>
+						<span className="text-[#555555]/50">Sold Out</span>
 					)}
 
-					<div className="grid grid-cols-2 gap-2">
-						<BaseButton
-							style="border"
-							size="xl"
-							disabled={product.status !== "AVAILABLE"}
-						>
-							장바구니
-						</BaseButton>
-						<BaseButton
-							size="xl"
-							disabled={product.status !== "AVAILABLE"}
-							onClick={onClick}
-						>
-							구매
-						</BaseButton>
-					</div>
+					{isAvailable ? (
+						<div className="grid grid-cols-2 gap-2">
+							<BaseButton style="border" size="xl">
+								장바구니
+							</BaseButton>
+							<BaseButton size="xl" onClick={onClick}>
+								구매
+							</BaseButton>
+						</div>
+					) : (
+						<div className="grid">
+							<BaseButton size="xl" onClick={onClick}>
+								재입고알림
+							</BaseButton>
+						</div>
+					)}
 				</div>
-				<h6>{product.description}</h6>
+				<p className="text-sm pt-24 text-gray-700 whitespace-pre-wrap">
+					{product.description}
+				</p>
 			</div>
 		</div>
 	);

--- a/src/components/product/ProductDetail.tsx
+++ b/src/components/product/ProductDetail.tsx
@@ -1,0 +1,67 @@
+import { Product } from "@/types/product";
+import Image from "next/image";
+import React, { useState } from "react";
+import BaseButton from "../common/Button/BaseButton";
+import NumberInput from "../common/Input/NumberInput";
+
+interface ProductDetailProps {
+	product: Product;
+}
+
+const ProductDetail = ({ product }: ProductDetailProps) => {
+	const [quantity, setQuantity] = useState<number>(1);
+	if (!product) return null;
+
+	return (
+		<div className="flex flex-col md:flex-row w-full gap-8">
+			<div className="relative w-full max-w-xl aspect-[4/5]">
+				<Image
+					src={product.imageUrl}
+					alt={product.name}
+					fill
+					sizes="100vw"
+					className="object-cover"
+					priority
+				/>
+			</div>
+			<div className="flex flex-col gap-4 w-full md:w-100">
+				<span className="text-2xl font-bold">{product.name}</span>
+
+				<div className="flex flex-col pt-20 gap-4">
+					<span className="text-2xl font-bold">
+						KRW {product.price.toLocaleString()}
+					</span>
+					{product.status === "AVAILABLE" ? (
+						<NumberInput
+							value={quantity}
+							onValueChange={setQuantity}
+							max={product.stock}
+						/>
+					) : (
+						<span>Sold Out</span>
+					)}
+
+					<div className="grid grid-cols-2 gap-2">
+						<BaseButton
+							style="border"
+							size="xl"
+							disabled={product.status !== "AVAILABLE"}
+						>
+							장바구니
+						</BaseButton>
+						<BaseButton
+							size="xl"
+							disabled={product.status !== "AVAILABLE"}
+							onClick={onClick}
+						>
+							구매
+						</BaseButton>
+					</div>
+				</div>
+				<h6>{product.description}</h6>
+			</div>
+		</div>
+	);
+};
+
+export default ProductDetail;

--- a/src/components/product/ProductDetail/ProductDetail.tsx
+++ b/src/components/product/ProductDetail/ProductDetail.tsx
@@ -1,23 +1,25 @@
 import { Product } from "@/types/product";
 import Image from "next/image";
-import React, { useState } from "react";
-import BaseButton from "../common/Button/BaseButton";
-import NumberInput from "../common/Input/NumberInput";
+import BaseButton from "../../common/Button/BaseButton";
+import NumberInput from "../../common/Input/NumberInput";
 import { formatPrice } from "@/utils/format";
+import useProductDetail from "./useProductDetail";
 
 interface ProductDetailProps {
 	product: Product;
 }
 
 const ProductDetail = ({ product }: ProductDetailProps) => {
-	const [quantity, setQuantity] = useState<number>(1);
-	if (!product) return null;
-
-	const isAvailable = product.status === "AVAILABLE";
-
-	const onClick = () => {
-		console.log("click");
-	};
+	const {
+		quantity,
+		setQuantity,
+		isAvailable,
+		onClickCart,
+		onClickOrder,
+		onClickAlarm,
+	} = useProductDetail({
+		product,
+	});
 
 	return (
 		<div className="flex flex-col md:flex-row w-full gap-8">
@@ -49,16 +51,16 @@ const ProductDetail = ({ product }: ProductDetailProps) => {
 
 					{isAvailable ? (
 						<div className="grid grid-cols-2 gap-2">
-							<BaseButton style="border" size="xl">
+							<BaseButton style="border" size="xl" onClick={onClickCart}>
 								장바구니
 							</BaseButton>
-							<BaseButton size="xl" onClick={onClick}>
+							<BaseButton size="xl" onClick={onClickOrder}>
 								구매
 							</BaseButton>
 						</div>
 					) : (
 						<div className="grid">
-							<BaseButton size="xl" onClick={onClick}>
+							<BaseButton size="xl" onClick={onClickAlarm}>
 								재입고알림
 							</BaseButton>
 						</div>

--- a/src/components/product/ProductDetail/useProductDetail.ts
+++ b/src/components/product/ProductDetail/useProductDetail.ts
@@ -1,0 +1,46 @@
+import { addProductToCart, orderProduct } from "@/app/api/product/route";
+import { Product } from "@/types/product";
+import { useCallback, useState } from "react";
+
+interface UseProductDetailProps {
+	product: Product;
+}
+
+const useProductDetail = ({ product }: UseProductDetailProps) => {
+	const [quantity, setQuantity] = useState<number>(1);
+
+	const isAvailable = product.status === "AVAILABLE";
+
+	const onClickCart = useCallback(async () => {
+		try {
+			await addProductToCart({ productId: product.id, quantity });
+			alert("장바구니에 담기 완료!");
+		} catch (error) {
+			console.log("장바구니 담기 실패", error);
+		}
+	}, [product.id, quantity]);
+
+	const onClickOrder = useCallback(async () => {
+		try {
+			await orderProduct({ productId: product.id, quantity });
+			alert("결제로 이동!");
+		} catch (error) {
+			console.log("결제로 이동 실패", error);
+		}
+	}, [product.id, quantity]);
+
+	const onClickAlarm = () => {
+		alert("재입고 알림은 서비스 예정!");
+	};
+
+	return {
+		quantity,
+		setQuantity,
+		isAvailable,
+		onClickCart,
+		onClickOrder,
+		onClickAlarm,
+	};
+};
+
+export default useProductDetail;

--- a/src/components/product/ProductDetail/useProductDetail.ts
+++ b/src/components/product/ProductDetail/useProductDetail.ts
@@ -11,21 +11,26 @@ const useProductDetail = ({ product }: UseProductDetailProps) => {
 
 	const isAvailable = product.status === "AVAILABLE";
 
-	const onClickCart = useCallback(async () => {
+	const onClickCart = useCallback(async (): Promise<boolean> => {
 		try {
 			await addProductToCart({ productId: product.id, quantity });
 			alert("장바구니에 담기 완료!");
+			return true;
 		} catch (error) {
+			alert("장바구니에 담기 실패ㅠㅠ");
 			console.log("장바구니 담기 실패", error);
+			return false;
 		}
 	}, [product.id, quantity]);
 
-	const onClickOrder = useCallback(async () => {
+	const onClickOrder = useCallback(async (): Promise<boolean> => {
 		try {
 			await orderProduct({ productId: product.id, quantity });
-			alert("결제로 이동!");
+			return true;
 		} catch (error) {
+			alert("구매에 실패했습니다.");
 			console.log("결제로 이동 실패", error);
+			return false;
 		}
 	}, [product.id, quantity]);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,3 +40,10 @@ body {
 	color: var(--foreground);
 	font-family: Arial, Helvetica, sans-serif;
 }
+
+/* 숫자 input의 기본 stepper 숨기기 */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}

--- a/src/types/button.d.ts
+++ b/src/types/button.d.ts
@@ -1,7 +1,7 @@
 import { ButtonHTMLAttributes, ReactNode } from "react";
 
 export type ButtonSize = "sm" | "md" | "lg" | "xl";
-export type ButtonStyle = "filled" | "text" | "icon" | "icon-round";
+export type ButtonStyle = "filled" | "border" | "icon" | "icon-round";
 export type ButtonColor = "dustyBlue" | "softKhaki" | "icon" | "white";
 
 export interface BaseButtonProps

--- a/src/types/product.d.ts
+++ b/src/types/product.d.ts
@@ -17,3 +17,8 @@ export interface Product {
 	stock: number;
 	status: string;
 }
+
+export interface OrderProduct {
+	productId: number;
+	quantity: number;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,2 @@
+export const formatPrice = (price: number) =>
+	`KRW ${price.toLocaleString("ko-KR")}`;


### PR DESCRIPTION
## 작업 내역
- 아이템 상세화면 UI를 구현했습니다.
- 숫자패드용 UI를 추가했습니다.
   - 위, 아래 버튼 아이콘이 없어서 라이브러리 추가했습니다.
- sold out일 경우 재입고알림 버튼을 임의로 추가했습니다.
- 현재 재고 갯수와 비교해서 많은 경우 오류 표시
- 장바구니, 구매 API 연결

+) 이 pr 머지되면 pull하신 뒤 라이브러리 싱크 부탁드립니다! (npm install인가..하는그거요..)

## 스크린샷
|매진|아이템 있을 때|
|--|--|
|<img width="1051" alt="image" src="https://github.com/user-attachments/assets/d74ac606-3a0e-42e2-8398-c9d7f3f1ecc6" />|<img width="1208" alt="스크린샷 2025-03-28 오후 2 51 10" src="https://github.com/user-attachments/assets/3895e3c3-0464-4dc0-9b88-cbeb7e7d71c0" />|
