### PR TITLE
로그인 정보 마이페이지와 연동, CSS 와 버그 수정

### DIFF
--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-// ✅ [1] 마이페이지 사용자 정보 조회 (GET)
+// 마이페이지 사용자 정보 조회 (GET)
 export async function GET(req: NextRequest) {
     try {
         const token = getAccessTokenFromHeader(req);
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
     }
 }
 
-// ✅ [2] 마이페이지 비밀번호 변경 (PATCH)
+// 마이페이지 비밀번호 변경 (PATCH)
 export async function PATCH(req: NextRequest) {
     return await requestUpdatePassword(req);
 }
@@ -68,7 +68,8 @@ async function requestUpdatePassword(req: NextRequest) {
     }
 }
 
-// ✅ [3] 마이페이지 회원 탈퇴 (Soft Delete, PATCH로 처리)
+
+// 마이페이지 회원 탈퇴 (Soft Delete, DELETE로 처리)
 export async function DELETE(req: NextRequest) {
     return await requestSoftDeleteUser(req);
 }
@@ -81,19 +82,13 @@ async function requestSoftDeleteUser(req: NextRequest) {
         }
 
         const res = await fetch(`${API_BASE_URL}/users/my`, {
-            method: "PATCH",
+            method: "DELETE",
             headers: {
-                "Content-Type": "application/json",
                 Authorization: `Bearer ${token}`,
             },
-            body: JSON.stringify({ status: "DELETED" }),
         });
 
-        const resultText = await res.text(); // 👈
-        console.log("회원탈퇴 응답:", resultText);
-        console.log("탈퇴 바디:", JSON.stringify({ status: "DELETED" }));
-
-        if (!res.ok) throw new Error("탈퇴 요청 실패");
+        if (!res.ok) throw new Error("회원 탈퇴 요청 실패");
 
         return NextResponse.json({ message: "회원 탈퇴 처리 완료" });
     } catch {

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -4,106 +4,110 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 // ✅ [1] 마이페이지 사용자 정보 조회 (GET)
 export async function GET(req: NextRequest) {
-	try {
-		const token = getAccessTokenFromHeader(req);
-		if (!token) {
-			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
-		}
+    try {
+        const token = getAccessTokenFromHeader(req);
+        if (!token) {
+            return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+        }
 
-		const res = await fetch(`${API_BASE_URL}/users/my`, {
-			headers: {
-				Authorization: `Bearer ${token}`,
-			},
-		});
+        const res = await fetch(`${API_BASE_URL}/users/my`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
 
-		if (!res.ok) throw new Error("사용자 정보를 불러오지 못했습니다.");
-		const data = await res.json();
-		return NextResponse.json(data);
-	} catch {
-		return NextResponse.json(
-			{ error: "사용자 정보를 불러오지 못했습니다." },
-			{ status: 500 }
-		);
-	}
+        if (!res.ok) throw new Error("사용자 정보를 불러오지 못했습니다.");
+        const data = await res.json();
+        return NextResponse.json(data);
+    } catch {
+        return NextResponse.json(
+            { error: "사용자 정보를 불러오지 못했습니다." },
+            { status: 500 }
+        );
+    }
 }
 
 // ✅ [2] 마이페이지 비밀번호 변경 (PATCH)
 export async function PATCH(req: NextRequest) {
-	return await requestUpdatePassword(req);
+    return await requestUpdatePassword(req);
 }
 
 async function requestUpdatePassword(req: NextRequest) {
-	const { password } = await req.json();
+    const { currentPassword, newPassword } = await req.json();
 
-	if (!password) {
-		return NextResponse.json(
-			{ error: "비밀번호가 필요합니다." },
-			{ status: 400 }
-		);
-	}
+    if (!currentPassword || !newPassword) {
+        return NextResponse.json(
+            { error: "현재 비밀번호와 새 비밀번호가 필요합니다." },
+            { status: 400 }
+        );
+    }
 
-	try {
-		const token = getAccessTokenFromHeader(req);
-		if (!token) {
-			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
-		}
+    try {
+        const token = getAccessTokenFromHeader(req);
+        if (!token) {
+            return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+        }
 
-		const res = await fetch(`${API_BASE_URL}/users/my`, {
-			method: "PATCH",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${token}`,
-			},
-			body: JSON.stringify({ password }),
-		});
+        const res = await fetch(`${API_BASE_URL}/users/my`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ currentPassword, newPassword }),
+        });
 
-		if (!res.ok) throw new Error("비밀번호 변경 실패");
+        if (!res.ok) throw new Error("비밀번호 변경 실패");
 
-		return NextResponse.json({ message: "비밀번호가 변경되었습니다." });
-	} catch {
-		return NextResponse.json(
-			{ error: "비밀번호 변경에 실패했습니다." },
-			{ status: 500 }
-		);
-	}
+        return NextResponse.json({ message: "비밀번호가 변경되었습니다." });
+    } catch {
+        return NextResponse.json(
+            { error: "비밀번호 변경에 실패했습니다." },
+            { status: 500 }
+        );
+    }
 }
 
 // ✅ [3] 마이페이지 회원 탈퇴 (Soft Delete, PATCH로 처리)
 export async function DELETE(req: NextRequest) {
-	return await requestSoftDeleteUser(req);
+    return await requestSoftDeleteUser(req);
 }
 
 async function requestSoftDeleteUser(req: NextRequest) {
-	try {
-		const token = getAccessTokenFromHeader(req);
-		if (!token) {
-			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
-		}
+    try {
+        const token = getAccessTokenFromHeader(req);
+        if (!token) {
+            return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+        }
 
-		const res = await fetch(`${API_BASE_URL}/users/my`, {
-			method: "PATCH",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${token}`,
-			},
-			body: JSON.stringify({ status: "DELETED" }),
-		});
+        const res = await fetch(`${API_BASE_URL}/users/my`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ status: "DELETED" }),
+        });
 
-		if (!res.ok) throw new Error("탈퇴 요청 실패");
+        const resultText = await res.text(); // 👈
+        console.log("회원탈퇴 응답:", resultText);
+        console.log("탈퇴 바디:", JSON.stringify({ status: "DELETED" }));
 
-		return NextResponse.json({ message: "회원 탈퇴 처리 완료" });
-	} catch {
-		return NextResponse.json(
-			{ error: "서버 오류로 탈퇴 실패" },
-			{ status: 500 }
-		);
-	}
+        if (!res.ok) throw new Error("탈퇴 요청 실패");
+
+        return NextResponse.json({ message: "회원 탈퇴 처리 완료" });
+    } catch {
+        return NextResponse.json(
+            { error: "서버 오류로 탈퇴 실패" },
+            { status: 500 }
+        );
+    }
 }
 
 // ✅ [공통] Authorization 헤더에서 Bearer 토큰 추출
 function getAccessTokenFromHeader(req: NextRequest): string | null {
-	const authHeader = req.headers.get("authorization");
-	if (!authHeader) return null;
-	const token = authHeader.split(" ")[1]; // "Bearer <token>"
-	return token || null;
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) return null;
+    const token = authHeader.split(" ")[1]; // "Bearer <token>"
+    return token || null;
 }

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -1,10 +1,21 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export async function GET() {
+// ✅ [1] 마이페이지 사용자 정보 조회 (GET)
+export async function GET(req: NextRequest) {
 	try {
-		const res = await fetch(`${API_BASE_URL}/users/my`);
+		const token = getAccessTokenFromHeader(req);
+		if (!token) {
+			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+		}
+
+		const res = await fetch(`${API_BASE_URL}/users/my`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+			},
+		});
+
 		if (!res.ok) throw new Error("사용자 정보를 불러오지 못했습니다.");
 		const data = await res.json();
 		return NextResponse.json(data);
@@ -16,12 +27,12 @@ export async function GET() {
 	}
 }
 
-// 마이페이지 비밀번호 수정 api 연동
-export async function PATCH(req: Request) {
-	return await requestUpdatePassword(req); // 실제 처리 함수
+// ✅ [2] 마이페이지 비밀번호 변경 (PATCH)
+export async function PATCH(req: NextRequest) {
+	return await requestUpdatePassword(req);
 }
 
-async function requestUpdatePassword(req: Request) {
+async function requestUpdatePassword(req: NextRequest) {
 	const { password } = await req.json();
 
 	if (!password) {
@@ -32,9 +43,17 @@ async function requestUpdatePassword(req: Request) {
 	}
 
 	try {
+		const token = getAccessTokenFromHeader(req);
+		if (!token) {
+			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+		}
+
 		const res = await fetch(`${API_BASE_URL}/users/my`, {
 			method: "PATCH",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
 			body: JSON.stringify({ password }),
 		});
 
@@ -49,16 +68,24 @@ async function requestUpdatePassword(req: Request) {
 	}
 }
 
-// 마이페이지 회원 탈퇴 api 연동 (Soft Delete)
-export async function DELETE() {
-	return await requestSoftDeleteUser();
+// ✅ [3] 마이페이지 회원 탈퇴 (Soft Delete, PATCH로 처리)
+export async function DELETE(req: NextRequest) {
+	return await requestSoftDeleteUser(req);
 }
 
-async function requestSoftDeleteUser() {
+async function requestSoftDeleteUser(req: NextRequest) {
 	try {
+		const token = getAccessTokenFromHeader(req);
+		if (!token) {
+			return NextResponse.json({ error: "토큰이 없습니다." }, { status: 401 });
+		}
+
 		const res = await fetch(`${API_BASE_URL}/users/my`, {
 			method: "PATCH",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
 			body: JSON.stringify({ status: "DELETED" }),
 		});
 
@@ -71,4 +98,12 @@ async function requestSoftDeleteUser() {
 			{ status: 500 }
 		);
 	}
+}
+
+// ✅ [공통] Authorization 헤더에서 Bearer 토큰 추출
+function getAccessTokenFromHeader(req: NextRequest): string | null {
+	const authHeader = req.headers.get("authorization");
+	if (!authHeader) return null;
+	const token = authHeader.split(" ")[1]; // "Bearer <token>"
+	return token || null;
 }

--- a/src/app/mypage/EditForm.tsx
+++ b/src/app/mypage/EditForm.tsx
@@ -23,7 +23,6 @@ export default function EditForm({ user, onCancel }: { user: { userId: string; n
                 <p><strong>이름:</strong> {user?.name || "name"}</p>
                 <label className="block text-gray-700 mt-[25px] mb-[5px]">현재 비밀번호</label>
                 <input type="password" name="currentPassword" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
-                <p className="text-xs text-gray-400 mt-1">현재 입력 값: {currentPassword}</p>
                 <label className="block text-gray-700 mt-[10px] mb-[5px]">새 비밀번호</label>
                 <input type="password" name="newPassword" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
                 <label className="block text-gray-700 mt-[10px] mb-[5px]">새 비밀번호 확인</label>

--- a/src/app/mypage/EditForm.tsx
+++ b/src/app/mypage/EditForm.tsx
@@ -3,13 +3,15 @@ import { useEditPasswordForm } from "./useEditPasswordForm";
 
 export default function EditForm({ user, onCancel }: { user: { userId: string; name: string } | null; onCancel: () => void }) {
     const {
-        password,
-        confirmPassword,
-        setPassword,
-        setConfirmPassword,
-        handleSubmit,
-        handleDelete,
-        message
+		currentPassword,
+		setCurrentPassword,
+		newPassword,
+		confirmPassword,
+		setNewPassword,
+		setConfirmPassword,
+		handleSubmit,
+		handleDelete,
+		message,
     } = useEditPasswordForm(onCancel);
 
     return (
@@ -19,10 +21,13 @@ export default function EditForm({ user, onCancel }: { user: { userId: string; n
             <form className="w-[300px] tracking-[2px]" onSubmit={handleSubmit}>
                 <p><strong>아이디:</strong> {user?.userId || "userId"}</p>
                 <p><strong>이름:</strong> {user?.name || "name"}</p>
-                <label className="block text-gray-700 mt-[25px] mb-[5px]">새 비밀번호</label>
-                <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
-                <label className="block text-gray-700 mt-[10px] mb-[5px]">비밀번호 확인</label>
-                <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
+                <label className="block text-gray-700 mt-[25px] mb-[5px]">현재 비밀번호</label>
+                <input type="password" name="currentPassword" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
+                <p className="text-xs text-gray-400 mt-1">현재 입력 값: {currentPassword}</p>
+                <label className="block text-gray-700 mt-[10px] mb-[5px]">새 비밀번호</label>
+                <input type="password" name="newPassword" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
+                <label className="block text-gray-700 mt-[10px] mb-[5px]">새 비밀번호 확인</label>
+                <input type="password" name="confirmPassword" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="border bg-white p-2 w-full h-[36px]" required />
                 <div className="flex gap-3 mt-[20px]">
                     <button type="submit" className="w-full bg-[var(--soft-black)] text-white py-2 rounded hover:bg-black">변경하기</button>
                     <button type="button" className="w-full bg-gray-600 text-white py-2 rounded hover:bg-gray-800" onClick={onCancel}>취소</button>

--- a/src/app/mypage/EditForm.tsx
+++ b/src/app/mypage/EditForm.tsx
@@ -12,7 +12,7 @@ export default function EditForm({ user, onCancel }: { user: { userId: string; n
 		handleSubmit,
 		handleDelete,
 		message,
-    } = useEditPasswordForm(onCancel);
+    } = useEditPasswordForm();
 
     return (
         <div className="max-w-md mx-auto mt-10 p-6 bg-white shadow-lg rounded-lg">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -10,7 +10,15 @@ export default function MyPage() {
     useEffect(() => {
         async function fetchUser() {
             try {
-                const res = await fetch("/api/mypage");
+                const token = localStorage.getItem("access_token");
+                if (!token) throw new Error("로그인 토큰이 없습니다.");
+
+                const res = await fetch("/api/mypage", {
+                    method: "GET",
+                    headers: {
+                        Authorization: `Bearer ${token}`, // 토큰 헤더로 전달
+                    },
+                });
                 if (!res.ok) throw new Error("사용자 정보를 불러오지 못했습니다.");
                 const data = await res.json();
                 setUser(data);

--- a/src/app/mypage/useEditPasswordForm.ts
+++ b/src/app/mypage/useEditPasswordForm.ts
@@ -4,7 +4,8 @@ import { validatePassword } from "@/utils/validate";
 import { useRouter } from "next/navigation";
 
 export function useEditPasswordForm(onSuccess: () => void) {
-  const [password, setPassword] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
   const router = useRouter();
@@ -12,14 +13,14 @@ export function useEditPasswordForm(onSuccess: () => void) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const passwordError = validatePassword(password);
+    const passwordError = validatePassword(newPassword);
     if (passwordError) {
       setMessage(passwordError);
       return;
     }
 
-    if (password !== confirmPassword) {
-      setMessage("비밀번호가 일치하지 않습니다.");
+    if (newPassword !== confirmPassword) {
+      setMessage("새 비밀번호가 일치하지 않습니다.");
       return;
     }
 
@@ -33,7 +34,10 @@ export function useEditPasswordForm(onSuccess: () => void) {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ password }),
+        body: JSON.stringify({
+          currentPassword: currentPassword, // 현재 비밀번호
+          newPassword: newPassword,     // 새 비밀번호
+        }),
       });
 
       if (!response.ok) throw new Error("비밀번호 변경 실패");
@@ -51,15 +55,15 @@ export function useEditPasswordForm(onSuccess: () => void) {
 
     try {
       const token = localStorage.getItem("access_token");
-			if (!token) throw new Error("로그인이 필요합니다.");
+      if (!token) throw new Error("로그인이 필요합니다.");
 
-			const res = await fetch("/api/mypage", {
-				method: "DELETE",
-				headers: {
-					Authorization: `Bearer ${token}`,
-				},
-			});
-      
+      const res = await fetch("/api/mypage", {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
       if (!res.ok) throw new Error("회원 탈퇴 실패");
 
       alert("회원 탈퇴가 완료되었습니다.");
@@ -70,12 +74,14 @@ export function useEditPasswordForm(onSuccess: () => void) {
   };
 
   return {
-    password,
-    confirmPassword,
-    setPassword,
-    setConfirmPassword,
-    handleSubmit,
-    handleDelete,
-    message,
+		currentPassword,
+		setCurrentPassword,
+		newPassword,
+		confirmPassword,
+		setNewPassword,
+		setConfirmPassword,
+		handleSubmit,
+		handleDelete,
+		message,
   };
 }

--- a/src/app/mypage/useEditPasswordForm.ts
+++ b/src/app/mypage/useEditPasswordForm.ts
@@ -4,63 +4,78 @@ import { validatePassword } from "@/utils/validate";
 import { useRouter } from "next/navigation";
 
 export function useEditPasswordForm(onSuccess: () => void) {
-	const [password, setPassword] = useState("");
-	const [confirmPassword, setConfirmPassword] = useState("");
-	const [message, setMessage] = useState("");
-	const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [message, setMessage] = useState("");
+  const router = useRouter();
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-		const passwordError = validatePassword(password);
-		if (passwordError) {
-			setMessage(passwordError);
-			return;
-		}
+    const passwordError = validatePassword(password);
+    if (passwordError) {
+      setMessage(passwordError);
+      return;
+    }
 
-		if (password !== confirmPassword) {
-			setMessage("비밀번호가 일치하지 않습니다.");
-			return;
-		}
+    if (password !== confirmPassword) {
+      setMessage("비밀번호가 일치하지 않습니다.");
+      return;
+    }
 
-		try {
-			const response = await fetch("/api/mypage", {
-				method: "PATCH",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ password }),
+    try {
+      const token = localStorage.getItem("access_token");
+      if (!token) throw new Error("로그인이 필요합니다.");
+
+      const response = await fetch("/api/mypage", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ password }),
+      });
+
+      if (!response.ok) throw new Error("비밀번호 변경 실패");
+
+      setMessage("비밀번호가 성공적으로 변경되었습니다.");
+      onSuccess(); // 변경 완료 시 콜백 호출 (닫기 처리 같은)
+    } catch {
+      setMessage("오류가 발생했습니다.");
+    }
+  };
+
+  // 회원 탈퇴
+  const handleDelete = async () => {
+    if (!confirm("정말로 회원 탈퇴하시겠습니까?")) return;
+
+    try {
+      const token = localStorage.getItem("access_token");
+			if (!token) throw new Error("로그인이 필요합니다.");
+
+			const res = await fetch("/api/mypage", {
+				method: "DELETE",
+				headers: {
+					Authorization: `Bearer ${token}`,
+				},
 			});
+      
+      if (!res.ok) throw new Error("회원 탈퇴 실패");
 
-			if (!response.ok) throw new Error("비밀번호 변경 실패");
+      alert("회원 탈퇴가 완료되었습니다.");
+      router.push("/");
+    } catch {
+      alert("탈퇴 중 오류가 발생했습니다.");
+    }
+  };
 
-			setMessage("비밀번호가 성공적으로 변경되었습니다.");
-			onSuccess(); // 변경 완료 시 콜백 호출 (닫기 처리 같은)
-		} catch {
-			setMessage("오류가 발생했습니다.");
-		}
-	};
-
-	// 회원 탈퇴
-	const handleDelete = async () => {
-		if (!confirm("정말로 회원 탈퇴하시겠습니까?")) return;
-
-		try {
-			const res = await fetch("/api/mypage", { method: "DELETE" });
-			if (!res.ok) throw new Error("회원 탈퇴 실패");
-
-			alert("회원 탈퇴가 완료되었습니다.");
-			router.push("/");
-		} catch {
-			alert("탈퇴 중 오류가 발생했습니다.");
-		}
-	};
-
-	return {
-		password,
-		confirmPassword,
-		setPassword,
-		setConfirmPassword,
-		handleSubmit,
-		handleDelete,
-		message,
-	};
+  return {
+    password,
+    confirmPassword,
+    setPassword,
+    setConfirmPassword,
+    handleSubmit,
+    handleDelete,
+    message,
+  };
 }

--- a/src/app/mypage/useEditPasswordForm.ts
+++ b/src/app/mypage/useEditPasswordForm.ts
@@ -4,7 +4,7 @@ import { validatePassword } from "@/utils/validate";
 import { useRouter } from "next/navigation";
 import useAuth from "@/hooks/useAuth";
 
-export function useEditPasswordForm(onSuccess: () => void) {
+export function useEditPasswordForm() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");

--- a/src/app/mypage/useEditPasswordForm.ts
+++ b/src/app/mypage/useEditPasswordForm.ts
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { validatePassword } from "@/utils/validate";
 import { useRouter } from "next/navigation";
+import useAuth from "@/hooks/useAuth";
 
 export function useEditPasswordForm(onSuccess: () => void) {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -9,6 +10,7 @@ export function useEditPasswordForm(onSuccess: () => void) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
   const router = useRouter();
+  const { logout } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,6 +67,8 @@ export function useEditPasswordForm(onSuccess: () => void) {
       });
 
       if (!res.ok) throw new Error("회원 탈퇴 실패");
+
+      logout(); // 로그아웃 처리
 
       alert("회원 탈퇴가 완료되었습니다.");
       router.push("/");

--- a/src/app/mypage/useEditPasswordForm.ts
+++ b/src/app/mypage/useEditPasswordForm.ts
@@ -44,8 +44,11 @@ export function useEditPasswordForm(onSuccess: () => void) {
 
       if (!response.ok) throw new Error("비밀번호 변경 실패");
 
-      setMessage("비밀번호가 성공적으로 변경되었습니다.");
-      onSuccess(); // 변경 완료 시 콜백 호출 (닫기 처리 같은)
+      logout(); // 로그아웃
+
+      alert("비밀번호가 변경되었습니다. 다시 로그인 해주세요.");
+      router.push("/");
+
     } catch {
       setMessage("오류가 발생했습니다.");
     }


### PR DESCRIPTION
## 작업 내역
- 로그인한 정보가 마이페이지와 연동됩니다
- 로그인한 정보로 비밀번호 수정과 회원 탈퇴가 가능해집니다
- 회원 탈퇴 시 자동으로 로그아웃되고, 홈으로 리다이렉트를 진행합니다
- 비밀번호 변경 시 자동으로 로그아웃되고, 홈으로 리다이렉트를 진행합니다
- API 상 비밀번호 수정 시 현재 비밀번호도 필요해 input 을 추가하고 연동했습니다
- 약간의 버그 수정

다행히 이번에는 테스트를 할 수 있었고, 정상 작동 되는 것 같아요 !
저 궁금한게 있습니다 🙌  Vercel 로 배포 하신거 깃헙에 있는 파일들이 자동으로 배포되는건가요?

## 스크린 샷
![image](https://github.com/user-attachments/assets/fc5b63e2-7886-4df6-9322-a051fbbcec23)
